### PR TITLE
Fixed upper/lower case typos in includes

### DIFF
--- a/OpenCV/src/Utils/kplot/PlotData.cpp
+++ b/OpenCV/src/Utils/kplot/PlotData.cpp
@@ -20,7 +20,7 @@
 #include <cmath>
 #include <limits>
 
-#include "Plotdata.h" 
+#include "PlotData.h"
 #include "opencvGraphics.h"
 
 

--- a/OpenCV/src/Utils/kplot/koolplot.cpp
+++ b/OpenCV/src/Utils/kplot/koolplot.cpp
@@ -10,7 +10,7 @@
  */
 #include <cmath>
 
-#include "Koolplot.h"
+#include "koolplot.h"
 
 namespace Plot {
 


### PR DESCRIPTION
Fixed typos in order to be able to compile
