### PR TITLE
Rounding: fixed comparison when number is integer

### DIFF
--- a/OpenCV/src/Utils/kplot/Plotstream.cpp
+++ b/OpenCV/src/Utils/kplot/Plotstream.cpp
@@ -101,7 +101,7 @@ static double floatRound(double val, int & sigDigits, long int &intrep)
 	   
 	// find position of dot if any
 	decPos = str.find('.');
-	if(unsigned(decPos) == std::string::npos) // then it's an integer, return now
+	if(decPos == std::string::npos) // then it's an integer, return now
 	{
 		sigDigits = str.size();
 		intrep = static_cast<long int>(val);


### PR DESCRIPTION
My system fails to compare these (unsigned ~ 32b, size_t ~ 64b). Anyway I believe, that the comparison should be performed directly and let the compiler do implicit conversion.

assume: decPos = -1
unsigned(decPos) == std::string::npos <=> 4294967296 == 18446744073709551616 <=> 0
versus
decPos == std::string::npos <=> (int)-1 == 18446744073709551616 <=> 18446744073709551616 == 18446744073709551616 <=> 0

This is just my assumption, I might be wrong.
